### PR TITLE
added 3/5v bridging and TP2 / TP2 connection instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ It works fine on my **one**, startech branded, KVM that I have test with. Given 
 ## PCBs
 There are two variants of the PCB available in the KiCad folder, Phat and Slim for your preference. The main circuit for both PCBs is the same so the firmware package will work on both PCBs. A full BOM for LCSC (except for header pins) is available in the Phat folder: [LCSC BOM](https://raw.githubusercontent.com/LimeProgramming/USB-serial-mouse-adapter/main/KiCad/Phat/BOM_LCSC.xls). For the Slim build you can omit the dip switches and reset switch (you will have to source an appropriate SMD reset switch).
 
-#### Building a PCB:
+### Building a PCB:
 
+#### MAX232/3232 voltage selection:
 The PCB has a jumper to select between 3.3v and 5v for the MAX chip. 
 - If you're using a MAX232 then bridge 5v to the center pin and install all the resistors. The part listed in the [BOM](https://raw.githubusercontent.com/LimeProgramming/USB-serial-mouse-adapter/main/KiCad/Phat/BOM_LCSC.xls) is a MAX232 chip.
 - If you're using a MAX3232 then bridge 3.3v to the center pin, bridge R4 and R3, and remove R1 and R2.
+
+#### Board to Pico USB data connection:
+The TP2 and TP3 testpoints on the board must be soldered to the corresponding TP2 and TP3 test points on the Pico, underneath the USB connector.
 
 
 ### Phat:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ It works fine on my **one**, startech branded, KVM that I have test with. Given 
 ## PCBs
 There are two variants of the PCB available in the KiCad folder, Phat and Slim for your preference. The main circuit for both PCBs is the same so the firmware package will work on both PCBs. A full BOM for LCSC (except for header pins) is available in the Phat folder: [LCSC BOM](https://raw.githubusercontent.com/LimeProgramming/USB-serial-mouse-adapter/main/KiCad/Phat/BOM_LCSC.xls). For the Slim build you can omit the dip switches and reset switch (you will have to source an appropriate SMD reset switch).
 
+#### Building a PCB:
+
+The PCB has a jumper to select between 3.3v and 5v for the MAX chip. 
+- If you're using a MAX232 then bridge 5v to the center pin and install all the resistors. The part listed in the [BOM](https://raw.githubusercontent.com/LimeProgramming/USB-serial-mouse-adapter/main/KiCad/Phat/BOM_LCSC.xls) is a MAX232 chip.
+- If you're using a MAX3232 then bridge 3.3v to the center pin, bridge R4 and R3, and remove R1 and R2.
+
 
 ### Phat:
 [<img align="center" alt="PHAT_PCB" width="650px" src="https://raw.githubusercontent.com/LimeProgramming/USB-serial-mouse-adapter/main/images/phat_readme_s.webp"/>](https://raw.githubusercontent.com/LimeProgramming/USB-serial-mouse-adapter/main/images/phat_readme.png)


### PR DESCRIPTION
Hi,

I got parts and boards and built one up, it was a really fun build, thank you!

The 3.3 / 5v bridge thing caught me out, so I added some instructions to the readme based on an old issue I found that you had answered. I'm still unsure if anything needs to be done with TP1 and TP2?

Would it be possible to add the diffs for cutemouse that you used to patch the baud rate? It would be nice to be able to rebuild it from source instead of just having the binaries. Similarly if you could add the windows drivers (I could pull them from vogons and submit a PR if you like?) and the source patches.

Thanks again for this excellent project.